### PR TITLE
Add Kubernetes deployment for imagePullSecret

### DIFF
--- a/cloud/kubernetes/helm/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/templates/_helpers.tpl
@@ -223,3 +223,13 @@ Create a openshift NFS path details for sharedNothing and store
     server: {{ .Values.persistentvolumes.openshift.volume.nfs.server }}
     path: {{ .Values.persistentvolumes.openshift.volume.nfs.sapath }}
 {{- end -}}
+
+{{- define "beimagepullsecret.fullname" -}}
+{{ .Release.Name }}-beimagepullsecret
+{{- end -}}
+
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}

--- a/cloud/kubernetes/helm/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/templates/_helpers.tpl
@@ -224,9 +224,11 @@ Create a openshift NFS path details for sharedNothing and store
     path: {{ .Values.persistentvolumes.openshift.volume.nfs.sapath }}
 {{- end -}}
 
-{{- define "beimagepullsecret.fullname" -}}
-{{ .Release.Name }}-beimagepullsecret
-{{- end -}}
+{{- define "beimagepullsecret.fullname" }}
+{{- if .Values.imageCredentials.registry }}
+{{- .Release.Name }}-beimagepullsecret
+{{- end }}
+{{- end }}
 
 {{- define "imagePullSecret" }}
 {{- with .Values.imageCredentials }}

--- a/cloud/kubernetes/helm/templates/becacheagent.yaml
+++ b/cloud/kubernetes/helm/templates/becacheagent.yaml
@@ -17,7 +17,7 @@ spec:
         name: {{ include "becacheagent.fullname" . }}
     spec:
       imagePullSecrets:
-        - name: {{ if .Values.imageCredentials.registry }}{{ include "beimagepullsecret.fullname" . }}{{ end }}
+        - name: {{ include "beimagepullsecret.fullname" . }}
       containers:
       - name: {{ .Values.cachenode.containers.name }}
         image: {{ .Values.image }}

--- a/cloud/kubernetes/helm/templates/becacheagent.yaml
+++ b/cloud/kubernetes/helm/templates/becacheagent.yaml
@@ -17,7 +17,7 @@ spec:
         name: {{ include "becacheagent.fullname" . }}
     spec:
       imagePullSecrets:
-        - name: {{ .Values.imagePullSecrets }}    #if required
+        - name: {{ if .Values.imageCredentials.registry }}{{ include "beimagepullsecret.fullname" . }}{{ end }}
       containers:
       - name: {{ .Values.cachenode.containers.name }}
         image: {{ .Values.image }}

--- a/cloud/kubernetes/helm/templates/beinferenceagent.yaml
+++ b/cloud/kubernetes/helm/templates/beinferenceagent.yaml
@@ -15,7 +15,7 @@ spec:
         name: {{ include "beinferenceagent.fullname" . }}
     spec:
       imagePullSecrets:
-        - name: {{ .Values.imagePullSecrets }}    #if required
+        - name: {{ if .Values.imageCredentials.registry }}{{ include "beimagepullsecret.fullname" . }}{{ end }}
       containers:
       - name: {{ .Values.inferencenode.containers.name }}
         image: {{ .Values.image }}

--- a/cloud/kubernetes/helm/templates/beinferenceagent.yaml
+++ b/cloud/kubernetes/helm/templates/beinferenceagent.yaml
@@ -15,7 +15,7 @@ spec:
         name: {{ include "beinferenceagent.fullname" . }}
     spec:
       imagePullSecrets:
-        - name: {{ if .Values.imageCredentials.registry }}{{ include "beimagepullsecret.fullname" . }}{{ end }}
+        - name: {{ include "beimagepullsecret.fullname" . }}
       containers:
       - name: {{ .Values.inferencenode.containers.name }}
         image: {{ .Values.image }}

--- a/cloud/kubernetes/helm/templates/imagepullsecret.yaml
+++ b/cloud/kubernetes/helm/templates/imagepullsecret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "{{ include "beimagepullsecret.fullname" . }}"
+  name: {{ include "beimagepullsecret.fullname" . }}
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/cloud/kubernetes/helm/templates/imagepullsecret.yaml
+++ b/cloud/kubernetes/helm/templates/imagepullsecret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.imageCredentials.registry }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "beimagepullsecret.fullname" . }}"
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/cloud/kubernetes/helm/values.yaml
+++ b/cloud/kubernetes/helm/values.yaml
@@ -14,8 +14,13 @@ cacheType: AS2                      #cacheType can be AS2, ignite
 # Image name and pull policy required for be app
 image: ftlsnapp
 imagePullPolicy: IfNotPresent
-imagePullSecrets:  #if required for azure
 
+# imageCredentials Credentials to pull image from a private registry. Provide these details, if BE docker image is available at private registry.
+imageCredentials:
+  registry:   #Ex: hub.docker.com
+  username:
+  password:
+  email:
 #*************************Agents env varaibles****************************************************
 
 ignite:


### PR DESCRIPTION
This PR eliminates manual steps to create imagePullSecret, when the BE app image is available in a private repository.