### PR TITLE
v1:pv provisioning for aws now supports static and dynamic provisioning

### DIFF
--- a/cloud/kubernetes/helm/Chart.lock
+++ b/cloud/kubernetes/helm/Chart.lock
@@ -2,14 +2,11 @@ dependencies:
 - name: mysql
   repository: https://charts.bitnami.com/bitnami
   version: 8.2.3
-- name: aws-efs-csi-driver
-  repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
-  version: 1.0.0
 - name: influxdb
   repository: https://helm.influxdata.com/
   version: 4.8.4
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.1.14
-digest: sha256:905c6f62e1176aeef6400bd42b0f072b63e071ab666334975033f902e74ba48a
-generated: "2021-02-09T15:20:51.1319091+05:30"
+digest: sha256:40707dae2686ad145dcf17213f4a79ce5406ff48f44f1440018d2cfd5b7ab2d1
+generated: "2021-05-21T11:41:41.213690255+05:30"

--- a/cloud/kubernetes/helm/Chart.yaml
+++ b/cloud/kubernetes/helm/Chart.yaml
@@ -22,10 +22,6 @@ dependencies:
     condition: mysql.enabled
     tags:
       - database
-  - name: aws-efs-csi-driver
-    version: 1.0.0
-    repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
-    condition: efs-driver.enabled
   - name: influxdb
     version: 4.8.4
     repository: https://helm.influxdata.com/   

--- a/cloud/kubernetes/helm/Helm-Chart.md
+++ b/cloud/kubernetes/helm/Helm-Chart.md
@@ -188,9 +188,8 @@ The command removes all the Kubernetes components associated with the chart
 Below dependencies are included in BE helm charts
 
 1. [MySQL chart](https://github.com/bitnami/charts/tree/master/bitnami/mysql): It installs MySQL deployment for the database requirements of the backingstore BE applications.
-2. [efs-provisioner chart](https://github.com/helm/charts/tree/master/stable/efs-provisioner): Used to fulfill PersistentVolumeClaims with EFS PersistentVolumes for the BE applications.
-3.  [influxdb chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb):  It's useful for recording metrics, events, and performing analytics.
-4. [Grafana chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana): Used for viewing BE application metrics.
+2.  [influxdb chart](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb):  It's useful for recording metrics, events, and performing analytics.
+3. [Grafana chart](https://github.com/grafana/helm-charts/tree/main/charts/grafana): Used for viewing BE application metrics.
 
 The persisent volumes are created as folders with in an [AWS EFS](https://aws.amazon.com/efs/)
 

--- a/cloud/kubernetes/helm/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/templates/_helpers.tpl
@@ -123,18 +123,19 @@ volumes:
 {{- if eq .Values.rms.persistenceType "sharednothing"}}      
   - name: {{ .Values.volumes.snmountVolume }}
     persistentVolumeClaim:
-      claimName: {{ .Release.Name }}-rms-{{ .Values.volumes.snmountVolume }}
+      claimName: {{ .Release.Name }}-rms-pvc-{{ .Values.volumes.snmountVolume }}
 {{- end }}
 {{- if eq .Values.mountLogs true }}      
   - name: {{ .Values.volumes.logmountVolume }}
     persistentVolumeClaim:
-      claimName: {{ .Release.Name }}-rms-{{ .Values.volumes.logmountVolume }}
+      claimName: {{ .Release.Name }}-rms-pvc-{{ .Values.volumes.logmountVolume }}
 {{- end }}
 {{- end }}
 {{- end -}}
 
 {{- define "volumeClaim" -}}
 {{- if or (eq .Values.mountLogs true) (eq .Values.bsType "sharednothing") }}
+{{- if eq .Values.volumes.pvProvisioningMode "dynamic" }}
   volumeClaimTemplates:
 {{- if eq .Values.bsType "sharednothing" }}  
     - metadata:
@@ -142,7 +143,7 @@ volumes:
         annotations:
           volume.beta.kubernetes.io/storage-class: {{ .Values.volumes.storageClass }}
       spec:
-        accessModes: {{ .Values.volumes.accessModes }}
+        accessModes: ["{{ .Values.volumes.accessModes }}"]
         resources:
           requests:
             storage: {{ .Values.volumes.storage }}
@@ -153,10 +154,22 @@ volumes:
         annotations:
           volume.beta.kubernetes.io/storage-class: {{ .Values.volumes.storageClass }}
       spec:
-        accessModes: {{ .Values.volumes.accessModes }}
+        accessModes: ["{{ .Values.volumes.accessModes }}"]
         resources:
           requests:
-            storage: {{ .Values.volumes.logStorage }}
+            storage: {{ .Values.volumes.storage }}
+{{- end }}
+{{- end }}
+{{- if eq .Values.volumes.pvProvisioningMode "static" }}
+{{- if eq .Values.rms.enabled false }}      
+      volumes:
+{{- end }}
+        - name: {{ .Values.volumes.snmountVolume }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-be-pvc-{{ .Values.volumes.snmountVolume }}
+        - name: {{ .Values.volumes.logmountVolume }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-be-pvc-{{ .Values.volumes.logmountVolume }}        
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/cloud/kubernetes/helm/templates/_helpers.tpl
+++ b/cloud/kubernetes/helm/templates/_helpers.tpl
@@ -463,3 +463,12 @@ affinity:
   value: {{ $val }}
 {{- end}}
 {{- end -}}
+
+{{- define "storageclass" -}}
+{{- if eq .Values.volumes.pvProvisioningMode "static" }}  
+  storageClassName: ""
+{{- end}}
+{{- if eq .Values.volumes.pvProvisioningMode "dynamic" }}
+  storageClassName: "{{ .Values.volumes.storageClass }}"
+{{- end}}
+{{- end -}}

--- a/cloud/kubernetes/helm/templates/beteagent.yaml
+++ b/cloud/kubernetes/helm/templates/beteagent.yaml
@@ -33,5 +33,5 @@ spec:
       volumes:
         - name: tealogs
           persistentVolumeClaim:
-            claimName: "{{ .Release.Name }}-tea-{{ .Values.volumes.logmountVolume }}"            
+            claimName: "{{ .Release.Name }}-tea-pvc-{{ .Values.volumes.logmountVolume }}"            
 {{- end -}}

--- a/cloud/kubernetes/helm/templates/pv-manifest.yaml
+++ b/cloud/kubernetes/helm/templates/pv-manifest.yaml
@@ -3,20 +3,8 @@
 # Copyright (c) 2019-2020. TIBCO Software Inc.
 # This file is subject to the license terms contained in the license file that is distributed with this file.
 #
-
-
-{{- if and (eq .Values.cpType "awsfargate" ) (eq .Values.bsType "sharednothing") }}
-apiVersion: storage.k8s.io/v1beta1
-kind: CSIDriver
-metadata:
-  name: efs.csi.aws.com
-spec:
-  attachRequired: false
-{{- end }}
-
----
-
-{{- if or (eq .Values.cpType "awsfargate") (eq .Values.volumes.storageClass "efs-sc") }}
+{{- if eq .Values.volumes.pvProvisioningMode "dynamic" }}
+{{- if and (eq .Values.cpType "aws") (ne .Values.volumes.storageClass "gp2") }}
 {{- if or (eq .Values.bsType "sharednothing") (eq .Values.mountLogs true) (eq .Values.rms.persistenceType "sharednothing") (eq .Values.rms.enabled true) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -26,61 +14,151 @@ provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
   fileSystemId: {{ .Values.aws.efsFileSystemId}}
-  directoryPerms: "700"
+  directoryPerms: "755"
 {{- end }}
 {{- end }}
----
+{{- end }}
 
-{{- if and (eq .Values.cpType "awsfargate") (eq .Values.volumes.storageClass "efs-sc") }}
-{{- if eq .Values.bsType "sharednothing" }}
-{{- $root := . -}}
-{{range untilStep 0 (.Values.cachenode.replicaCount | int) 1 }}
+{{- if and (eq .Values.cpType "aws") (eq .Values.volumes.pvProvisioningMode "static") }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: "efs-pv-cache-{{.}}"
+  name: "{{ .Release.Name }}-be-pv-{{ .Values.volumes.snmountVolume }}"
 spec:
   capacity:
-    storage: 5Gi
+    storage: "{{ .Values.volumes.storage }}"
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{$root.Values.volumes.storageClass}}"
+  storageClassName: "{{ .Values.volumes.storageClass }}"
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: "{{$root.Values.aws.efsFileSystemId}}"
+    volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
   claimRef:
     namespace: default
-    name: {{$root.Values.volumes.snmountVolume}}-{{ $.Release.Name }}-{{- $root.Values.cachenode.name -}}-{{.}}
+    name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.snmountVolume }}"
 ---
-{{end}}
-{{- end }}
 {{- end }}
 
-{{- if and (eq .Values.cpType "awsfargate") (eq .Values.volumes.storageClass "efs-sc") }}
-{{- if eq .Values.bsType "sharednothing" }}
-{{- $root := . -}}
-{{range untilStep 0 (.Values.inferencenode.replicaCount | int) 1 }}
+{{- if and (eq .Values.cpType "aws") (eq .Values.volumes.pvProvisioningMode "static") ( eq .Values.mountLogs true ) }}
+---
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: "efs-pv-inference-{{.}}"
+  name: "{{ .Release.Name }}-be-pv-{{ .Values.volumes.logmountVolume }}"
 spec:
   capacity:
-    storage: 5Gi
+    storage: "{{ .Values.volumes.storage }}"
   volumeMode: Filesystem
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.volumes.accessModes }}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "{{ .Values.volumes.storageClass }}"
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
+  claimRef:
+    namespace: default
+    name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.logmountVolume }}"
+---
+{{- end }}
+
+{{- if and (eq .Values.volumes.pvProvisioningMode "static") (eq .Values.cpType "aws") ( eq .Values.rms.enabled true ) }}
+{{- $root := . -}}
+{{- $releasename:= .Release.Name  -}}
+{{- range tuple "security" "notify" "webstudio" "shared" }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ $releasename }}-rms-pv-{{.}}"
+spec:
+  capacity:
+    storage: "{{ $root.Values.volumes.storage }}"
+  volumeMode: Filesystem
+  accessModes:
+    - {{ $root.Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
   storageClassName: "{{$root.Values.volumes.storageClass }}"
   csi:
     driver: efs.csi.aws.com
-    volumeHandle: "{{$root.Values.aws.efsFileSystemId }}"
+    volumeHandle: "{{$root.Values.aws.efsFileSystemId}}:/{{.}}"
   claimRef:
     namespace: default
-    name: {{$root.Values.volumes.snmountVolume}}-{{ $.Release.Name }}-{{- $root.Values.inferencenode.name -}}-{{.}}
+    name: "{{ $releasename }}-rms-pvc-{{.}}"
 ---
-{{end}}
+{{- end }}
+{{- end }}
+
+{{- if and (eq .Values.cpType "aws") (eq .Values.volumes.pvProvisioningMode "static") ( eq .Values.rms.enabled true ) (eq .Values.rms.persistenceType "sharednothing") }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ .Release.Name }}-rms-pv-{{ .Values.volumes.snmountVolume }}"
+spec:
+  capacity:
+    storage: "{{ .Values.volumes.storage }}"
+  volumeMode: Filesystem
+  accessModes:
+    - {{ .Values.volumes.accessModes }}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "{{ .Values.volumes.storageClass }}"
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
+  claimRef:
+    namespace: default
+    name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.snmountVolume }}"
+---
+{{- end }}
+
+{{- if and (eq .Values.cpType "aws") (eq .Values.volumes.pvProvisioningMode "static") ( eq .Values.rms.enabled true ) ( eq .Values.mountLogs true ) }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ .Release.Name }}-rms-pv-{{ .Values.volumes.logmountVolume }}"
+spec:
+  capacity:
+    storage: "{{ .Values.volumes.storage }}"
+  volumeMode: Filesystem
+  accessModes:
+    - {{ .Values.volumes.accessModes }}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "{{ .Values.volumes.storageClass }}"
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
+  claimRef:
+    namespace: default
+    name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.logmountVolume }}"
+---
+{{- end }}
+
+{{- if and (eq .Values.cpType "aws") (eq .Values.volumes.pvProvisioningMode "static") }}
+{{- if and ( eq .Values.mountLogs true ) ( eq .Values.tea.enabled true ) }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: "{{ .Release.Name }}-tea-pv-{{ .Values.volumes.logmountVolume }}"
+spec:
+  capacity:
+    storage: "{{ .Values.volumes.storage }}"
+  volumeMode: Filesystem
+  accessModes:
+    - {{ .Values.volumes.accessModes }}
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: "{{ .Values.volumes.storageClass }}"
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
+  claimRef:
+    namespace: default
+    name: "{{ .Release.Name }}-tea-pvc-{{ .Values.volumes.logmountVolume }}"
+---
 {{- end }}
 {{- end }}

--- a/cloud/kubernetes/helm/templates/pv-manifest.yaml
+++ b/cloud/kubernetes/helm/templates/pv-manifest.yaml
@@ -32,7 +32,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
@@ -55,7 +55,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
@@ -105,7 +105,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
@@ -128,7 +128,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
@@ -152,7 +152,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"

--- a/cloud/kubernetes/helm/templates/rms-pvc.yaml
+++ b/cloud/kubernetes/helm/templates/rms-pvc.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  storageClassName: "{{  .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -27,7 +27,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  storageClassName: "{{  .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -41,6 +41,7 @@ spec:
 {{- $scStorage  :=  .Values.volumes.storage -}}
 {{- $accessmodes:= .Values.volumes.accessModes -}}
 {{- $releasename:= .Release.Name  -}}
+{{- $pvProvisioningMode := .Values.volumes.pvProvisioningMode -}}
 {{- range tuple "security" "notify" "webstudio" "shared" }}
 ---
 kind: PersistentVolumeClaim
@@ -48,7 +49,12 @@ apiVersion: v1
 metadata:
   name: "{{ $releasename}}-rms-pvc-{{.}}"
 spec:
+{{- if eq $pvProvisioningMode "static" }}  
+  storageClassName: ""
+{{- end}}
+{{- if eq $pvProvisioningMode "dynamic" }}
   storageClassName: "{{ $scName }}"
+{{- end}}
   accessModes:
     - {{ $accessmodes }}
   resources:
@@ -65,7 +71,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  storageClassName: "{{  .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -81,7 +87,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  storageClassName: "{{  .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -96,7 +102,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-tea-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  storageClassName: "{{  .Values.volumes.storageClass }}"
+  {{ include "storageclass" . }}
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:

--- a/cloud/kubernetes/helm/templates/rms-pvc.yaml
+++ b/cloud/kubernetes/helm/templates/rms-pvc.yaml
@@ -3,23 +3,54 @@
 # This file is subject to the license terms contained in the license file that is distributed with this file.
 #
 
-#Create persistent volumeClaims for RMS 
-{{- if eq .Values.rms.enabled true }}
-{{- $scName  :=  .Values.volumes.storageClass -}}
-{{- $scStorage  :=  .Values.volumes.storage -}}
-{{- $release:= .Release.Name -}}
-{{- range tuple "rms-pvc-security" "rms-pvc-notify" "rms-pvc-webstudio" "rms-pvc-shared" }}
+
+{{- if and (eq .Values.bsType "sharednothing") (eq .Values.volumes.pvProvisioningMode "static") (eq .Values.cpType "aws") }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ $release }}-{{.}}"
-  annotations:
-    volume.beta.kubernetes.io/storage-class: {{ $scName }}
+  name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  storageClassName: {{ $scName }}
+  storageClassName: "{{  .Values.volumes.storageClass }}"
+  accessModes: 
+    - {{ .Values.volumes.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.volumes.storage }}
+{{- end -}}
+
+
+{{- if and (eq .Values.mountLogs true) (eq .Values.volumes.pvProvisioningMode "static") (eq .Values.cpType "aws") }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.logmountVolume }}"
+spec:
+  storageClassName: "{{  .Values.volumes.storageClass }}"
+  accessModes: 
+    - {{ .Values.volumes.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.volumes.storage }}
+{{- end -}}
+
+
+{{- if eq .Values.rms.enabled true }}
+{{- $scName  :=  .Values.volumes.storageClass -}}
+{{- $scStorage  :=  .Values.volumes.storage -}}
+{{- $accessmodes:= .Values.volumes.accessModes -}}
+{{- $releasename:= .Release.Name  -}}
+{{- range tuple "security" "notify" "webstudio" "shared" }}
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: "{{ $releasename}}-rms-pvc-{{.}}"
+spec:
+  storageClassName: "{{ $scName }}"
   accessModes:
-    - ReadWriteMany
+    - {{ $accessmodes }}
   resources:
     requests:
       storage: {{ $scStorage }}
@@ -32,16 +63,14 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ .Release.Name }}-rms-{{ .Values.volumes.snmountVolume }}"
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "{{ .Values.volumes.storageClass }}"
+  name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  storageClassName: "{{  .Values.volumes.storageClass }}"
   accessModes: 
-    - ReadWriteOnce
+    - {{ .Values.volumes.accessModes }}
   resources:
     requests:
-      storage: "{{ .Values.volumes.storage }}"
+      storage: {{ .Values.volumes.storage }}
 {{- end -}}
 
 
@@ -50,16 +79,14 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ .Release.Name }}-rms-{{ .Values.volumes.logmountVolume }}"
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "{{ .Values.volumes.storageClass }}"
+  name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  storageClassName: "{{  .Values.volumes.storageClass }}"
   accessModes: 
-    - ReadWriteOnce
+    - {{ .Values.volumes.accessModes }}
   resources:
     requests:
-      storage: "{{ .Values.volumes.storage }}"
+      storage: {{ .Values.volumes.storage }}
 {{- end -}}
 
 {{- if and ( eq .Values.mountLogs true ) ( eq .Values.tea.enabled true ) }}
@@ -67,14 +94,12 @@ spec:
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: "{{ .Release.Name }}-tea-{{ .Values.volumes.logmountVolume }}"
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "{{ .Values.volumes.storageClass }}"
+  name: "{{ .Release.Name }}-tea-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  storageClassName: "{{ .Values.volumes.storageClass }}"
+  storageClassName: "{{  .Values.volumes.storageClass }}"
   accessModes: 
-    - ReadWriteOnce
+    - {{ .Values.volumes.accessModes }}
   resources:
     requests:
-      storage: "{{ .Values.volumes.storage }}"
+      storage: {{ .Values.volumes.storage }}
 {{- end -}}

--- a/cloud/kubernetes/helm/values.yaml
+++ b/cloud/kubernetes/helm/values.yaml
@@ -9,7 +9,7 @@
 # Declare variables to be passed into your templates.
 
 #Required parameter to be passed for all cloud providers
-cpType: minikube      #cpType can be minikube, aws, awsfargate, azure, openshift, gcp or oci
+cpType: minikube      #cpType can be minikube, aws, azure, openshift, gcp or oci
 #-----------------------------------------
 cmType: unclustered                     #cmType can be unclustered,as2,ftl,ignite
 omType: inmemory                        #omType can be inmemory,store,cache
@@ -125,12 +125,12 @@ healthcheck:
     initialDelaySeconds: 5 
     periodSeconds: 5 
 
-# Resource memory for EKS Fargate pods
+# Resource memory for pods
 resources:
   memory: 1Gi
   cpu: 1
 aws:
-  efsFileSystemId: fs-12345678   #update for awsfargate(cpType=awsfargate) - for EKS and KOPS cluster with efs set volumes.storageClass=efs-sc
+  efsFileSystemId: fs-12345678   #update for aws efs(cpType=aws) - for dynamic provisioning of pv and pvc's set volumes.storageClass=efs-sc
 
 #*************************Service Part****************************************************
 #Required for cache, sharednothing, store in all cloud providers
@@ -224,14 +224,14 @@ as4database:
 #*************************Volumes Part****************************************************
 volumes:
   #Required for sharednothing and store in all cloud providers
+  pvProvisioningMode: dynamic                 # Default set to dynamic, For aws eks(dynamic or static) and fargate set to `static`, and keep the storgeclass empty 
   snmountPath: "/mnt/tibco/be/data-store"
   snmountVolume: store
   logmountPath: "/mnt/tibco/be/logs"
   logmountVolume: applog
-  accessModes: ["ReadWriteOnce"]
+  accessModes: "ReadWriteOnce"
   storage: 0.5Gi
-  logStorage: 0.5Gi
-  storageClass: standard                    #Use one of the available storage classes as per your preference, for aws efs file system set storageclass: efs-sc
+  storageClass: standard                    #Use one of the available storage classes as per your preference, for aws cluster with  `pvProvisioningMode:dynamic` efs file system it creates a new storageclass, for `pvProvisioningMode:static` leave the storageclass field empty
   snclaimVolume: pv0003
 
 #Required for store in  all cloud providers
@@ -248,10 +248,6 @@ mysql:
   auth:
     rootPassword: password12
     database: BE_DATABASE  #database name
-
-# Required for sharednothing and store data in AWS EFS(Only for volumes.storageClass=efs-sc)
-efs-driver:
-  enabled: false              #use true to create aws-efs provisioner.If you enable this, update volumes.storageClass to "efs-sc" 
 
 # ---------------------------------Information related to metrics(influx/liveview)-------------------------------------------------
 

--- a/cloud/kubernetes/helm/values.yaml
+++ b/cloud/kubernetes/helm/values.yaml
@@ -229,7 +229,7 @@ volumes:
   snmountVolume: store
   logmountPath: "/mnt/tibco/be/logs"
   logmountVolume: applog
-  accessModes: "ReadWriteOnce"
+  accessModes: "ReadWriteMany"
   storage: 0.5Gi
   storageClass: standard                    #Use one of the available storage classes as per your preference, for aws cluster with  `pvProvisioningMode:dynamic` efs file system it creates a new storageclass, for `pvProvisioningMode:static` leave the storageclass field empty
   snclaimVolume: pv0003


### PR DESCRIPTION
This PR includes below changes:

- Update cpType: valid values - from `awsfargate` to `aws`(includes,eks,kops and fargate)
- Add new kv pair for static and dynamic provision of PV's in aws cluster
- When pvProvisioningMode set to static, helm generates required PV & PVCs (by referring filesystem ID, etc)
- When pvProvisioningMode set to dynamic, the user needs to supply storageClass name to use.
