### PR TITLE
update storage class functionality for dynamic pvprovision

### DIFF
--- a/cloud/kubernetes/helm/templates/pv-manifest.yaml
+++ b/cloud/kubernetes/helm/templates/pv-manifest.yaml
@@ -4,17 +4,19 @@
 # This file is subject to the license terms contained in the license file that is distributed with this file.
 #
 {{- if eq .Values.volumes.pvProvisioningMode "dynamic" }}
-{{- if and (eq .Values.cpType "aws") (ne .Values.volumes.storageClass "gp2") }}
+{{- if eq .Values.cpType "aws" }}
+{{- if empty .Values.volumes.storageClass }}
 {{- if or (eq .Values.bsType "sharednothing") (eq .Values.mountLogs true) (eq .Values.rms.persistenceType "sharednothing") (eq .Values.rms.enabled true) }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: "{{ .Values.volumes.storageClass }}"
+  name: "{{ include "storageclass" . | trim }}"
 provisioner: efs.csi.aws.com
 parameters:
   provisioningMode: efs-ap
   fileSystemId: {{ .Values.aws.efsFileSystemId}}
   directoryPerms: "755"
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -32,7 +34,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  {{ include "storageclass" . }}
+  storageClassName:  "{{ include "storageclass" . | trim }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
@@ -55,7 +57,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
@@ -68,6 +70,7 @@ spec:
 {{- if and (eq .Values.volumes.pvProvisioningMode "static") (eq .Values.cpType "aws") ( eq .Values.rms.enabled true ) }}
 {{- $root := . -}}
 {{- $releasename:= .Release.Name  -}}
+{{- $storageclass:= include "storageclass" . | trim  -}}
 {{- range tuple "security" "notify" "webstudio" "shared" }}
 ---
 apiVersion: v1
@@ -81,7 +84,7 @@ spec:
   accessModes:
     - {{ $root.Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: "{{$root.Values.volumes.storageClass }}"
+  storageClassName: "{{ $storageclass }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{$root.Values.aws.efsFileSystemId}}:/{{.}}"
@@ -105,7 +108,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.snmountVolume }}"
@@ -128,7 +131,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"
@@ -152,7 +155,7 @@ spec:
   accessModes:
     - {{ .Values.volumes.accessModes }}
   persistentVolumeReclaimPolicy: Retain
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   csi:
     driver: efs.csi.aws.com
     volumeHandle: "{{ .Values.aws.efsFileSystemId}}:/{{ .Values.volumes.logmountVolume }}"

--- a/cloud/kubernetes/helm/templates/rms-pvc.yaml
+++ b/cloud/kubernetes/helm/templates/rms-pvc.yaml
@@ -11,7 +11,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -27,7 +27,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-be-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -41,20 +41,17 @@ spec:
 {{- $scStorage  :=  .Values.volumes.storage -}}
 {{- $accessmodes:= .Values.volumes.accessModes -}}
 {{- $releasename:= .Release.Name  -}}
+{{- $storageclass:= include "storageclass" . | trim  -}}
 {{- $pvProvisioningMode := .Values.volumes.pvProvisioningMode -}}
+{{- $root := . -}}
 {{- range tuple "security" "notify" "webstudio" "shared" }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: "{{ $releasename}}-rms-pvc-{{.}}"
-spec:
-{{- if eq $pvProvisioningMode "static" }}  
-  storageClassName: ""
-{{- end}}
-{{- if eq $pvProvisioningMode "dynamic" }}
-  storageClassName: "{{ $scName }}"
-{{- end}}
+spec:  
+  storageClassName: "{{ $storageclass }}"
   accessModes:
     - {{ $accessmodes }}
   resources:
@@ -71,7 +68,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.snmountVolume }}"
 spec:
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -87,7 +84,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-rms-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:
@@ -102,7 +99,7 @@ apiVersion: v1
 metadata:
   name: "{{ .Release.Name }}-tea-pvc-{{ .Values.volumes.logmountVolume }}"
 spec:
-  {{ include "storageclass" . }}
+  storageClassName: "{{ include "storageclass" . | trim }}"
   accessModes: 
     - {{ .Values.volumes.accessModes }}
   resources:


### PR DESCRIPTION
This PR included below changes

1. pvProvision=static -> storageclass field is ignored. configs (pv, pvcs) should generate with empty "" sc name
2. pvProvision=dynamic, cpType=aws, storageclass="" -> new sc(releasename-be-sc) gets created same would be used.
3. pvProvision=dynamic, cpType=aws, storageclass="ABC" -> dont generate new sc. use the sc(ABC)
4. pvProvision=dynamic, cpType=minikube, storageclass="ABC" -> same as pt3