### PR TITLE
fix rms login in windows

### DIFF
--- a/cloud/docker/build_image.bat
+++ b/cloud/docker/build_image.bat
@@ -876,7 +876,7 @@ if !INSTALLATION_TYPE! EQU frominstallers (
     powershell -Command "(Get-Content '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!\bin\be-engine.tra') -replace @(Select-String -Path '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!\bin\be-engine.tra' -Pattern '^tibco.env.TIB_HOME').Line.Substring(19), 'c:/tibco' | Set-Content '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!\bin\be-engine.tra'"
 
     if !IMAGE_NAME! EQU !RMS_IMAGE! (
-        powershell -Command "Copy-Item '!BE_HOME!\examples\standard\WebStudio' -Destination '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!\examples\standard' -Recurse | out-null"
+        powershell -Command "Copy-Item '!BE_HOME!\examples\standard\WebStudio' -Destination '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!\examples\standard\WebStudio' -Recurse | out-null"
 
         if EXIST "!BE_HOME!\decisionmanager" (
             powershell -Command "Copy-Item '!BE_HOME!\decisionmanager' -Destination '!TEMP_FOLDER!\tibcoHome\be\!ARG_BE_SHORT_VERSION!' -Recurse | out-null"

--- a/cloud/docker/dockerfiles/Dockerfile-rms.win
+++ b/cloud/docker/dockerfiles/Dockerfile-rms.win
@@ -110,9 +110,7 @@ VOLUME \
     "c:\mnt\tibco\be\logs" \
     "c:\mnt\tibco\be\data-store" \
     "${BE_HOME}\rms\config\notify" \
-    "${BE_HOME}\rms\config\security" \
-    "${BE_HOME}\rms\shared" \
-    "${BE_HOME}\examples\standard\WebStudio"
+    "${BE_HOME}\rms\shared"
 
 # The following is the list of communication ports that need to be open-n-available
 # Port 50000 is AS Listener Port, 50001 is AS Remote Listener Port, 5555 is JMX Port, RMS PORTs 8090 5000

--- a/cloud/docker/dockerfiles/Dockerfile-rms_fromtar.win
+++ b/cloud/docker/dockerfiles/Dockerfile-rms_fromtar.win
@@ -52,9 +52,7 @@ VOLUME \
     "c:\mnt\tibco\be\logs" \
     "c:\mnt\tibco\be\data-store" \
     "${BE_HOME}\rms\config\notify" \
-    "${BE_HOME}\rms\config\security" \
-    "${BE_HOME}\rms\shared" \
-    "${BE_HOME}\examples\standard\WebStudio"
+    "${BE_HOME}\rms\shared"
 
 # The following is the list of communication ports that need to be open-n-available
 # # Port 50000 is AS Listener Port, 50001 is AS Remote Listener Port, 5555 is JMX Port, #RMS PORTs 8090 5000


### PR DESCRIPTION
Removes security and webstudio from volumes in docker file.
Fixed missing webstudio folder in examples/standard for Dockerfile-rms_fromtar.win file, which causes loading example projects in webstudio